### PR TITLE
[WFCORE-2717] try-catch block doesn't work if catch block doesn't contains anything

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/trycatch/TryCatchFinallyControlFlow.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/trycatch/TryCatchFinallyControlFlow.java
@@ -57,6 +57,7 @@ class TryCatchFinallyControlFlow implements CommandLineRedirection {
     private int state;
 
     TryCatchFinallyControlFlow(CommandContext ctx) {
+        tryList = new ArrayList<>();
         ctx.set(Scope.CONTEXT, CTX_KEY, this);
     }
 
@@ -97,6 +98,9 @@ class TryCatchFinallyControlFlow implements CommandLineRedirection {
     }
 
     void moveToCatch() throws CommandLineException {
+        if(catchList == null) {
+            catchList = new ArrayList<>();
+        }
         switch(state) {
             case IN_TRY:
                 state = IN_CATCH;
@@ -111,6 +115,9 @@ class TryCatchFinallyControlFlow implements CommandLineRedirection {
     }
 
     void moveToFinally() throws CommandLineException {
+        if(finallyList == null) {
+            finallyList = new ArrayList<>();
+        }
         switch(state) {
             case IN_TRY:
                 state = IN_FINALLY;
@@ -128,21 +135,12 @@ class TryCatchFinallyControlFlow implements CommandLineRedirection {
     private void addLine(String line) {
         switch(state) {
             case IN_TRY:
-                if(tryList == null) {
-                    tryList = new ArrayList<String>();
-                }
                 tryList.add(line);
                 break;
             case IN_CATCH:
-                if(catchList == null) {
-                    catchList = new ArrayList<String>();
-                }
                 catchList.add(line);
                 break;
             case IN_FINALLY:
-                if(finallyList == null) {
-                    finallyList = new ArrayList<String>();
-                }
                 finallyList.add(line);
                 break;
             default:

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/TryCatchFinallyTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/TryCatchFinallyTestCase.java
@@ -329,4 +329,52 @@ public class TryCatchFinallyTestCase extends CLISystemPropertyTestBase {
             cliOut.reset();
         }
     }
+
+    @Test
+    public void testCommentOnlyCatchBlock() throws Exception {
+        cliOut.reset();
+        final CommandContext ctx = CLITestUtil.getCommandContext(cliOut);
+        try {
+            ctx.connectController();
+            ctx.handle("try");
+            ctx.handle("echo try block");
+            ctx.handle(getReadNonexistingPropReq());
+            ctx.handle("catch");
+            ctx.handle("# commented line");
+            ctx.handleSafe("end-try");
+            ctx.handle("echo after-block");
+            String out = cliOut.toString();
+            assertTrue(out.contains("try block"));
+            assertTrue(out.contains("after-block"));
+            assertFalse(out.contains("system-property"));
+        } finally {
+            ctx.terminateSession();
+            cliOut.reset();
+        }
+    }
+
+    @Test
+    public void testCommentOnlyCatchAndFinallyBlock() throws Exception {
+        cliOut.reset();
+        final CommandContext ctx = CLITestUtil.getCommandContext(cliOut);
+        try {
+            ctx.connectController();
+            ctx.handle("try");
+            ctx.handle("echo try block");
+            ctx.handle(getReadNonexistingPropReq());
+            ctx.handle("catch");
+            ctx.handle("# commented line");
+            ctx.handle("finally");
+            ctx.handle("# commented line");
+            ctx.handleSafe("end-try");
+            ctx.handle("echo after-block");
+            String out = cliOut.toString();
+            assertTrue(out.contains("try block"));
+            assertTrue(out.contains("after-block"));
+            assertFalse(out.contains("system-property"));
+        } finally {
+            ctx.terminateSession();
+            cliOut.reset();
+        }
+    }
 }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFCORE-2717